### PR TITLE
HTML compresor bugfix

### DIFF
--- a/lib/emcee/processors/processor_scripts.rb
+++ b/lib/emcee/processors/processor_scripts.rb
@@ -14,7 +14,7 @@ module Emcee
             absolute_path = File.absolute_path(path, directory)
             script_contents = read_file(absolute_path)
 
-            to_inline << [script_tag, indent + "<script>" + script_contents + "</script>"]
+            to_inline << [script_tag, indent + "<script>" + script_contents + "\n</script>"]
           end
         end
 


### PR DESCRIPTION
HTML compressor trims closing script tag of inline scripts if last line of the script is comment.
Script example https://raw.githubusercontent.com/Polymer/platform/master/platform.js
