### PR TITLE
Adds support for slim templates

### DIFF
--- a/lib/generators/emcee/install/install_generator.rb
+++ b/lib/generators/emcee/install/install_generator.rb
@@ -16,11 +16,21 @@ module Emcee
       end
 
       def add_html_import_to_layout
-        insert_into_file "app/views/layouts/application.html.erb", "<%= html_import_tag \"application\", \"data-turbolinks-track\" => true %>\n  ", before: "<%= csrf_meta_tags %>"
+        if preprocessor? 'erb'
+          insert_into_file "app/views/layouts/application.html.erb", "<%= html_import_tag \"application\", \"data-turbolinks-track\" => true %>\n  ", before: "<%= csrf_meta_tags %>"
+        elsif preprocessor? 'slim'
+          insert_into_file "app/views/layouts/application.slim", "= html_import_tag \"application\", \"data-turbolinks-track\" => true\n  ", before: "= csrf_meta_tags"
+        end
       end
 
       def copy_bowerrc
         copy_file ".bowerrc", ".bowerrc"
+      end
+
+      private
+      def preprocessor?(preprocessor_name)
+        layout_file_name = 'app/views/layouts/application'
+        File.exists?("#{layout_file_name}.html.#{preprocessor_name}") || File.exists?("#{layout_file_name}.#{preprocessor_name}")
       end
     end
   end


### PR DESCRIPTION
Simple solution to allow the installation of `emcee` with a different preprocessor than `erb`.
