### PR TITLE
Escape </script and <!-- in inlined <script>s.

### DIFF
--- a/lib/emcee/processors/script_processor.rb
+++ b/lib/emcee/processors/script_processor.rb
@@ -18,9 +18,17 @@ module Emcee
         doc.script_references.each do |node|
           path = @resolver.absolute_path(node.path)
           return unless @resolver.should_inline?(path)
-          content = @resolver.evaluate(path)
-          node.replace("script", content)
+          script = @resolver.evaluate(path)
+          node.replace("script", escape_with_slash(script))
         end
+      end
+
+      def escape_with_slash(script)
+        script = script.sub('<!--', '<!\\--')
+        script.gsub!(/<\/\s*script/i) do |match|
+          match.sub '</', '<\\/'
+        end
+        script
       end
     end
   end


### PR DESCRIPTION
This is necessary to be able to use Polymer 0.5.1 with emcee.

Scripts that contain the string `</script` close the `<script>` tag when inlined. This occurs in real code (e.g., in polymer 0.5.1), so it needs to be worked around.

This change escapes scripts that contain the string `</script` (and variations w/ whitespace) and `<!--`, using the same tricks as [Polymer vulcanize](https://github.com/Polymer/vulcanize/)

I look forward to your feedback!
