### PR TITLE
Define stylesheet- and script references as dependencies for context

### DIFF
--- a/lib/emcee/processors/script_processor.rb
+++ b/lib/emcee/processors/script_processor.rb
@@ -20,6 +20,7 @@ module Emcee
           return unless @resolver.should_inline?(path)
           script = @resolver.evaluate(path)
           node.replace("script", escape_with_slash(script))
+          @resolver.depend_on_asset(path)
         end
       end
 

--- a/lib/emcee/processors/stylesheet_processor.rb
+++ b/lib/emcee/processors/stylesheet_processor.rb
@@ -20,6 +20,7 @@ module Emcee
           return unless @resolver.should_inline?(path)
           content = @resolver.evaluate(path)
           node.replace("style", content)
+          @resolver.depend_on_asset(path)
         end
       end
     end

--- a/lib/emcee/resolver.rb
+++ b/lib/emcee/resolver.rb
@@ -12,6 +12,11 @@ module Emcee
       @context.require_asset(path)
     end
 
+    # Allows to state an asset dependency without including it
+    def depend_on_asset(path)
+      @context.depend_on_asset(path)
+    end
+
     # Return the contents of a file. Does any required processing, such as SCSS
     # or CoffeeScript.
     def evaluate(path)

--- a/test/processors_test.rb
+++ b/test/processors_test.rb
@@ -7,7 +7,7 @@ require 'emcee/document'
 # Create a stub of our asset resolver, so we can test if we're sending the
 # correct messages to it.
 class ResolverStub
-  attr_reader :asset_required
+  attr_reader :asset_required, :asset_dependent
 
   def initialize(contents)
     @contents = contents
@@ -19,6 +19,10 @@ class ResolverStub
 
   def require_asset(asset)
     @asset_required = true
+  end
+
+  def depend_on_asset(asset)
+    @asset_dependent = true
   end
 
   def evaluate(path)
@@ -67,6 +71,7 @@ class ProcessorsTest < ActiveSupport::TestCase
       <p>test</p>
     EOS
 
+    assert @resolver.asset_dependent
     assert_equal correct, processed
   end
 
@@ -81,6 +86,7 @@ class ProcessorsTest < ActiveSupport::TestCase
       <p>test</p>
     EOS
 
+    assert @resolver.asset_dependent
     assert_equal correct, processed
   end
 
@@ -116,4 +122,3 @@ class ProcessorsTest < ActiveSupport::TestCase
     assert_equal correct, processed
   end
 end
-

--- a/test/resolver_test.rb
+++ b/test/resolver_test.rb
@@ -4,7 +4,7 @@ require 'emcee/resolver.rb'
 # Create a stub of Sprocket's Context class, so we can test if we're sending
 # the correct messages to it.
 class ContextStub
-  attr_reader :asset_required, :evaluated
+  attr_reader :asset_required, :asset_dependent, :evaluated
 
   def pathname
     "/"
@@ -12,6 +12,10 @@ class ContextStub
 
   def require_asset(asset)
     @asset_required = true
+  end
+
+  def depend_on_asset(asset)
+    @asset_dependent = true
   end
 
   def evaluate(path, options = {})
@@ -32,6 +36,11 @@ class ResolverTest < ActiveSupport::TestCase
   test "should require assets" do
     @resolver.require_asset("/asset1")
     assert @context.asset_required
+  end
+
+  test "should set dependencies on assets" do
+    @resolver.depend_on_asset("/dependency")
+    assert @context.asset_dependent
   end
 
   test "should evaluate an asset" do


### PR DESCRIPTION
This ensures referenced assets invalidate their source-file on change.

Compare [Sprockets::Context#depend_on_asset](http://www.rubydoc.info/github/sstephenson/sprockets/Sprockets/Context:depend_on_asset)

This should fix #24 .
