### PR TITLE
Import shim attributes properly

### DIFF
--- a/lib/emcee/node.rb
+++ b/lib/emcee/node.rb
@@ -17,6 +17,7 @@ module Emcee
     def replace(type, new_content)
       new_node = Nokogiri::XML::Node.new(type, document)
       new_node.content = new_content
+      new_node.set_attribute(shim, "") if shim
       @parser_node.replace(new_node)
     end
 
@@ -28,6 +29,10 @@ module Emcee
 
     def src
       @parser_node.attribute("src")
+    end
+
+    def shim
+      @parser_node.attribute("no-shim").try!(:name) || @parser_node.attribute("shim-shadowdom").try!(:name)
     end
 
     def document

--- a/test/dummy/app/assets/components/simple_css/index.html
+++ b/test/dummy/app/assets/components/simple_css/index.html
@@ -1,2 +1,2 @@
-<link rel="stylesheet" href="test.css">
+<link rel="stylesheet" href="test.css" shim-shadowdom>
 <p>Test css</p>

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -20,4 +20,3 @@ module Dummy
     # config.i18n.default_locale = :de
   end
 end
-

--- a/test/dummy_app_integration_test.rb
+++ b/test/dummy_app_integration_test.rb
@@ -10,7 +10,8 @@ class DummyAppIntegrationTest < ActionController::TestCase
   # compiled html import as a json response. We test against that here.
   test "the test files should get compiled and concatenated" do
     get :assets
-    assert_equal @response.body, <<-EOS.strip_heredoc
+
+    expected_body = <<-EOS.strip_heredoc
       <script>(function() {
         var hello;
         hello = "world";
@@ -26,7 +27,7 @@ class DummyAppIntegrationTest < ActionController::TestCase
       <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
       <p>Test external js</p>
       <p>Test simple import</p>
-      <style>p {
+      <style shim-shadowdom="">p {
         color: red;
       }
       </style>
@@ -45,5 +46,7 @@ class DummyAppIntegrationTest < ActionController::TestCase
         </template>
       </polymer-element>
     EOS
+
+    assert_equal expected_body, @response.body
   end
 end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 class Helpers < ActionView::TestCase
   test "html_import should work" do
-    assert_equal "<link href=\"/components/test.html\" rel=\"import\" />", html_import_tag("test")
+    assert_equal "<link rel=\"import\" href=\"/components/test.html\" />", html_import_tag("test")
   end
 end


### PR DESCRIPTION
Should fix #36 and #31

As it was explained in #36, the stylesheet processor wasn't properly taking `no-shim` and `shim-shadowdom` attributes into account.

This sets a new attribute to the node when shim attribute is available.
